### PR TITLE
Add device ID, name and type to msg.projectLink

### DIFF
--- a/nodes/project-link.html
+++ b/nodes/project-link.html
@@ -384,6 +384,9 @@
             This property contains information about the source of the message.
             <ul>
                 <li><code>projectId</code> - the id of the project that sent the message</li>
+                <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
+                <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
+                <li><code>deviceType</code> - if present, the type of the device that sent the message</li>
                 <li><code>topic</code> - the topic the message was received on</li>
                 <li><code>callStack</code> - when using the Project Call node, this contains
                  information about the call stack. This property must not be modified.</li>
@@ -458,6 +461,9 @@
             This property contains information about the source of the message.
             <ul>
                 <li><code>projectId</code> - the id of the project that sent the message</li>
+                <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
+                <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
+                <li><code>deviceType</code> - if present, the type of the device that sent the message</li>
                 <li><code>topic</code> - the topic the message was received on</li>
                 <li><code>callStack</code> - when using the Project Call node, this contains
                     information about the call stack. This property must not be modified.</li>

--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -227,6 +227,11 @@ module.exports = function (RED) {
                     projectId: packet.properties?.userProperties?._projectID,
                     topic: topic.split('/').slice(6).join('/')
                 }
+                if (packet.properties?.userProperties?._deviceId) {
+                    msg.projectLink.deviceId = packet.properties?.userProperties?._deviceId
+                    msg.projectLink.deviceName = packet.properties?.userProperties?._deviceName
+                    msg.projectLink.deviceType = packet.properties?.userProperties?._deviceType
+                }
             } catch (error) {
                 err = error
             }
@@ -451,6 +456,11 @@ module.exports = function (RED) {
                 pubOptions.properties = Object.assign({}, options.properties)
                 pubOptions.properties.userProperties = pubOptions.properties.userProperties || {}
                 pubOptions.properties.userProperties._projectID = RED.settings.flowforge.projectID
+                if (process.env.FF_DEVICE_ID) {
+                    pubOptions.properties.userProperties._deviceId = process.env.FF_DEVICE_ID
+                    pubOptions.properties.userProperties._deviceName = process.env.FF_DEVICE_NAME
+                    pubOptions.properties.userProperties._deviceType = process.env.FF_DEVICE_TYPE
+                }
                 pubOptions.properties.userProperties._nodeID = node.id
                 pubOptions.properties.userProperties._publishTime = Date.now()
                 pubOptions.properties.contentType = 'application/json'


### PR DESCRIPTION

## Description
Adds additional properties to `msg.projectLink` that identifies the device msg
* `deviceId`
* `deviceName`
* `deviceType`

![image](https://user-images.githubusercontent.com/44235289/212733172-ddd3464f-cc08-4f79-b971-32b2e5c2d317.png)

Update nodes built-in help detailing the additional properties


closes #17

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
     - [ ] No tests exist & setup requires full broker - will raise issue/task
 - [x] Documentation has been updated
    - [x] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

