### PR TITLE
Update docs to reflect project to instances naming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FlowForge Project Nodes
 
-A collection of Node-RED nodes for easy communication between projects running
-in the [FlowForge platform](https://flowforge.com).
+A collection of Node-RED nodes for easy communication between Node-RED instances
+running in the [FlowForge platform](https://flowforge.com).
 
 These nodes act in a similar way to the core Node-RED Link nodes - but can be
-used to send and receive messages between different Node-RED projects.
+used to send and receive messages between different Node-RED instances.
 
 Whilst these nodes are published under the Apache-2.0 license, they can only be
 used with an instance of the FlowForge platform with an active EE license applied.
@@ -23,14 +23,14 @@ now to try these nodes out.
 
 There are three nodes in this collection:
 
- - `Project In` - listens for messages being broadcast by other projects, or for
-   messages being sent just to this project
- - `Project Out` - sends messages to other projects
- - `Project Call` - sends messages to other projects and waits for a response
+ - `Project In` - listens for messages being broadcast by other Node-RED instances, or for
+   messages being sent just to this instance
+ - `Project Out` - sends messages to other Node-RED instances
+ - `Project Call` - sends messages to other Node-RED instances and waits for a response
 
-The nodes send the whole `msg` object between projects. Due to the way the nodes
-encode messages, there are some data types that do not get sent. For example,
-the `msg.req`/`msg.res` properties used by the core HTTP nodes will not be sent.
+The nodes send the whole `msg` object. Due to the way the nodes encode messages,
+there are some data types that do not get sent. For example, the `msg.req`/`msg.res`
+properties used by the core HTTP nodes will not be sent.
 
 Each node is configured with a topic on which it either sends or receives messages
 on. This is similar in concept to MQTT topics - although the nodes do not currently

--- a/nodes/project-link.html
+++ b/nodes/project-link.html
@@ -23,7 +23,7 @@
         <label><i class="fa fa-sign-in"></i> <span>Source</span></label>
         <span class="ff-project-link-group-option">
             <input type="radio" id="ff-project-link-radio-input-direct" name="ff-project-link-broadcast" value="false" checked />
-            <label for="ff-project-link-radio-input-direct">Receive messages sent to this project</label>
+            <label for="ff-project-link-radio-input-direct">Receive messages sent to this instance</label>
         </span>
     </div>
     <div class="form-row ff-project-link-list-row">
@@ -61,7 +61,7 @@
         <label><i class="fa fa-sign-out"></i> <span>Target</span></label>
         <span class="ff-project-link-group-option">
             <input type="radio" id="ff-project-link-radio-input-direct" name="ff-project-link-broadcast" value="false" checked />
-            <label for="ff-project-link-radio-input-direct">Send message to project</label>
+            <label for="ff-project-link-radio-input-direct">Send message to instance</label>
         </span>
     </div>
     <div class="form-row ff-project-link-list-row">
@@ -73,7 +73,7 @@
         <label><span>&nbsp</span></label>
         <span class="ff-project-link-group-option">
             <input type="radio" id="ff-project-link-radio-input-broadcast" name="ff-project-link-broadcast" value="true" />
-            <label for="ff-project-link-radio-input-broadcast">Broadcast message to all projects</label>
+            <label for="ff-project-link-radio-input-broadcast">Broadcast message to all instances</label>
         </span>
     </div>
     <div class="form-row ff-project-link-topic-row">
@@ -219,7 +219,7 @@
                 // broadcast not permitted in link call at this time but has been
                 // considered in the code base - possible future iteration
                 if (nodeType === 'project link in') {
-                    el.append(new Option('all projects', 'all', false, val === 'all'))
+                    el.append(new Option('all instances', 'all', false, val === 'all'))
                 }
                 const projects = (data.count ? data.projects : null) || []
                 for (let index = 0; index < projects.length; index++) {
@@ -364,10 +364,10 @@
 </script>
 
 <script type="text/html" data-help-name="project link in">
-    <p>Receive messages from other projects within your FlowForge Team</p>
+    <p>Receive messages from other Node-RED instances within your FlowForge Team</p>
     <h3>Details</h3>
-    <p>This node can either listen for messages broadcast by other projects,
-        or listen for messages sent directly to this project.</p>
+    <p>This node can either listen for messages broadcast by other instances,
+        or listen for messages sent directly to this instance.</p>
     <p>The node is configured with a <code>topic</code> to listen on. This works
        like an MQTT topic - allowing projects to send messages targeting different
        subscribers.</p>
@@ -377,13 +377,14 @@
     <dl class="message-properties">
         <dt><i>msg</i> <span class="property-type">object</span></dt>
         <dd>
-            The message sent by another project to this node.
+            The message sent by another Node-RED instance to this node.
         </dd>
         <dt><i>projectLink</i> <span class="property-type">object</span></dt>
         <dd>
             This property contains information about the source of the message.
             <ul>
-                <li><code>projectId</code> - the id of the project that sent the message</li>
+                <li><code>instanceId</code> - the id of the instance that sent the message</li>
+                <li><code>projectId</code> - <i>deprecated</i>: the id of the instance that sent the message</li>
                 <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
                 <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
                 <li><code>deviceType</code> - if present, the type of the device that sent the message</li>
@@ -398,19 +399,19 @@
 <script type="text/html" data-help-name="project link out">
     <p>Send messages to other projects within your FlowForge Team</p>
     <h3>Details</h3>
-    <p>This node can be used to send messages to other projects.</p>
+    <p>This node can be used to send messages to other Node-RED instances.</p>
     <p>
         It provides three modes of operation:
         <ul>
-            <li>send messages to another project</li>
-            <li>broadcast messages to any project listening on the same topic</li>
+            <li>send messages to another instance</li>
+            <li>broadcast messages to any instance listening on the same topic</li>
             <li>return the message to its sender if it originated from a Project Call node</li>
         </ul>
     </p>
     <p>
-        When configured to send or broadcast messages to other projects, the node
+        When configured to send or broadcast messages to other instances, the node
         is configured with a <code>topic</code> to send on. This works
-        like an MQTT topic - allowing projects to send messages targeting different
+        like an MQTT topic - allowing instances to send messages targeting different
         subscribers.
     </p>
     <p>
@@ -434,10 +435,10 @@
 </script>
 
 <script type="text/html" data-help-name="project link call">
-    <p>Send messages to other projects with your FlowForge Team and get a response back</p>
+    <p>Send messages to other Node-RED instances within your FlowForge Team and get a response back</p>
     <h3>Details</h3>
     <p>
-        This node can be used to send messages to other projects and then wait
+        This node can be used to send messages to other instances and then wait
         for a response to be sent back.
     </p>
     <p>
@@ -447,20 +448,21 @@
     </p>
     <p>
         The node is configured with a <code>topic</code> to send on. This works
-        like an MQTT topic - allowing projects to send messages targeting different
+        like an MQTT topic - allowing instances to send messages targeting different
         subscribers.
     </p>
     <h3>Output</h3>
     <dl class="message-properties">
         <dt><i>msg</i> <span class="property-type">object</span></dt>
         <dd>
-            The message sent by another project to this node.
+            The message sent by another instance to this node.
         </dd>
         <dt><i>projectLink</i> <span class="property-type">object</span></dt>
         <dd>
             This property contains information about the source of the message.
             <ul>
-                <li><code>projectId</code> - the id of the project that sent the message</li>
+                <li><code>instanceId</code> - the id of the instance that sent the message</li>
+                <li><code>projectId</code> - <i>deprecated</i>: the id of the instance that sent the message</li>
                 <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
                 <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
                 <li><code>deviceType</code> - if present, the type of the device that sent the message</li>

--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -3,7 +3,7 @@ module.exports = function (RED) {
 
     // Do not register nodes in runtime if settings not provided
     if (!RED.settings.flowforge || !RED.settings.flowforge.projectID || !RED.settings.flowforge.teamID || !RED.settings.flowforge.projectLink) {
-        throw new Error('Project Link nodes cannot be loaded outside of flowforge EE environment')
+        throw new Error('Project Link nodes cannot be loaded outside of FlowForge EE environment')
     }
 
     // Imports
@@ -225,6 +225,7 @@ module.exports = function (RED) {
                 msg = JSON.parse(message.toString(), jsonReviver)
                 msg.projectLink = {
                     ...msg.projectLink,
+                    instanceId: packet.properties?.userProperties?._projectID,
                     projectId: packet.properties?.userProperties?._projectID,
                     topic: topic.split('/').slice(6).join('/')
                 }


### PR DESCRIPTION
Closes #22 

I've added `msg.projectLink.instanceId` and (docs-only) deprecated `msg.projectLink.projectId`.