### PR TITLE
Fix frequent disconnections - Ensure keepalive is set

### DIFF
--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -510,6 +510,9 @@ module.exports = function (RED) {
                     }
                     options = Object.assign({}, defaultOptions, options)
 
+                    // ensure keepalive is set (defaults to sub 60s to avoid timeout due to AWS ALB timeout that defaults to 60 seconds)
+                    options.keepalive = options.keepalive || 45
+
                     if (RED.settings.flowforge.projectLink.broker.clientId) {
                         options.clientId = RED.settings.flowforge.projectLink.broker.clientId
                     } else {

--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -510,7 +510,7 @@ module.exports = function (RED) {
                     }
                     options = Object.assign({}, defaultOptions, options)
 
-                    // ensure keepalive is set (defaults to sub 60s to avoid timeout due to AWS ALB timeout that defaults to 60 seconds)
+                    // ensure keepalive is set (defaults to sub 60s to avoid timeout in load balancer)
                     options.keepalive = options.keepalive || 45
 
                     if (RED.settings.flowforge.projectLink.broker.clientId) {


### PR DESCRIPTION
## Description

Ensure `keepalive` is set to a value sub 60s to avoid AWS ALB timeout of 60s

I have tested various values locally, connecting up to staging. 45s provides a very stable env (1h seen 0 drops, previously I would see ~50 drops per hour when averaged over 8h monitoring)

## Related Issue(s)

#14 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

