### PR TITLE
Add node-red container build dispatch in the node package build pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
 
   publish:
     needs: build
-    # if: |
-    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-    #   github.event_name == 'schedule'
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: nr-project-nodes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
-      - name: Trigger localfs package rebuild
+      - name: Trigger node-red container build
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: nodered-container.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
 
   publish:
     needs: build
-    if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
+    # if: |
+    #   github.event_name == 'push' &&
+    #   github.ref == 'refs/heads/main'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: nr-project-nodes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,22 @@ jobs:
     with:
       package_name: nr-project-nodes
       publish_package: true
+
+  dispatch_container_build:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+      - name: Trigger localfs package rebuild
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: nodered-container.yml
+          repo: flowforge/helm
+          ref: main
+          token: ${{ steps.generate_token.outputs.token }}
+          inputs: '{"nr_project_nodes_ref": "${{ github.ref }}", "nr_project_nodes_release_name": "${{ needs.publish.outputs.release_name }}"}'


### PR DESCRIPTION
## Description

Add node-red container build workflow dispatch in the node package build pipeline, after successful package publish.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

