### PR TITLE
Fix `undefined (reading 'name')` error when `msg` is from a `http-in` node

### DIFF
--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -76,11 +76,11 @@ module.exports = function (RED) {
             // NOTE: Map and Set objects that are built in a function VM do NOT
             // evaluate to true when tested for instanceof Map or Set. Instead
             // constructor.name and .entries/.keys properties are used to determine type
-            if (value instanceof Map || (value.constructor.name === 'Map' && value.entries)) {
+            if (value instanceof Map || (value.constructor?.name === 'Map' && value.entries)) {
                 return wrapper('Map', [...value])
-            } else if (value instanceof Set || (value.constructor.name === 'Set' && value.values)) {
+            } else if (value instanceof Set || (value.constructor?.name === 'Set' && value.values)) {
                 return wrapper('Set', [...value])
-            } else if (Buffer.isBuffer(value) || (value.constructor.name === 'Buffer')) {
+            } else if (Buffer.isBuffer(value) || (value.constructor?.name === 'Buffer')) {
                 return value.toJSON()
             }
         }


### PR DESCRIPTION
## Description

1. Check `constructor` is something before attempting to read the `name` property. This reveals the real exception - which in the case of the HTTP-In `msg` object was a circular ref error 
2. When a `msg` contains the HTTP In node `req`/`res` properties is passed through project-call nodes, detach the properties then re-attach them when the response comes in.  


![image](https://github.com/flowforge/flowforge-nr-project-nodes/assets/44235289/6de60a84-cedc-4070-b590-0d90bd8d3d2e)


## Related Issue(s)

#42 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

