### PR TITLE
ci: Use NodeJS v24 to build package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
               {"version": "16", "tests": true, "lint": false},
               {"version": "18", "tests": true, "lint": true},
               {"version": "20", "tests": true, "lint": true},
+              {"version": "24", "tests": true, "lint": true},
             ]'
 
   publish:


### PR DESCRIPTION
## Description

This pull request sets the NodeJS version to 24 for build npm package reusable workflow

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/1180

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label