### PR TITLE
fix: explain invalid project link targets and name the target on a call timeout

### DIFF
--- a/nodes/project-link.html
+++ b/nodes/project-link.html
@@ -190,14 +190,14 @@
                 $('.ff-project-link-list-row').show()
                 $('#node-input-projectList').prop('disabled', isBroadcast ? true : null)
             } else if (node.type === 'project link in') {
-                // NOTE: Application assigned devices do not support direct messaging, therefore
+                // NOTE: Remote instances assigned to an application do not support direct messaging, therefore
                 // don't permit "Receive messages sent to this instance" on the project-in node
                 // when settings.RED.settings.ownerType is "application"
                 const directOptionParent = $('#ff-project-link-radio-input-direct').parent()
                 if (RED.settings.projectLinkInNode_ownerType === 'application') {
                     // update the label to reflect the fact that direct messaging is not supported
-                    directOptionParent.children('label').text('Receive messages sent to this device')
-                    RED.popover.tooltip(directOptionParent.children(), 'Option not supported when a device is assigned to an application')
+                    directOptionParent.children('label').text('Receive messages sent to this remote instance')
+                    RED.popover.tooltip(directOptionParent.children(), 'Not supported for a remote instance assigned to an application: use broadcast instead')
                     directOptionParent.children().prop('disabled', true)
                     directOptionParent.children().addClass('disabled')
                     isBroadcast = true
@@ -274,7 +274,7 @@
                 // broadcast not permitted in link call at this time but has been
                 // considered in the code base - possible future iteration
                 if (nodeType === 'project link in') {
-                    el.append(new Option('all instances and devices', 'all', false, val === 'all'))
+                    el.append(new Option('all instances and remote instances', 'all', false, val === 'all'))
                 }
 
                 for (let index = 0; index < instances.length; index++) {
@@ -445,7 +445,7 @@
 <script type="text/html" data-help-name="project link in">
     <p>Receive messages from other Node-RED instances within your FlowFuse Team</p>
     <h3>Details</h3>
-    <p>This node can either listen for messages broadcast by other instances and devices,
+    <p>This node can either listen for messages broadcast by other instances and remote instances,
         or listen for messages sent directly to this instance.</p>
     <p>The node is configured with a <code>topic</code> to listen on. This works
        like an MQTT topic - allowing instances to send messages targeting different
@@ -464,9 +464,9 @@
             <ul>
                 <li><code>instanceId</code> - the id of the instance that sent the message</li>
                 <li><code>projectId</code> - <i>deprecated</i>: the id of the instance that sent the message</li>
-                <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
-                <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
-                <li><code>deviceType</code> - if present, the type of the device that sent the message</li>
+                <li><code>deviceId</code> - if present, the id of the remote instance that sent the message</li>
+                <li><code>deviceName</code> - if present, the name of the remote instance that sent the message</li>
+                <li><code>deviceType</code> - if present, the type of the remote instance that sent the message</li>
                 <li><code>topic</code> - the topic the message was received on</li>
                 <li><code>callStack</code> - when using the Project Call node, this contains
                  information about the call stack. This property must not be modified.</li>
@@ -483,7 +483,7 @@
         It provides three modes of operation:
         <ul>
             <li>send messages to another instance</li>
-            <li>broadcast messages to any instance or device listening on the same topic</li>
+            <li>broadcast messages to any instance or remote instance listening on the same topic</li>
             <li>return the message to its sender if it originated from a Project Call node</li>
         </ul>
     </p>
@@ -542,9 +542,9 @@
             <ul>
                 <li><code>instanceId</code> - the id of the instance that sent the message</li>
                 <li><code>projectId</code> - <i>deprecated</i>: the id of the instance that sent the message</li>
-                <li><code>deviceId</code> - if present, the id of the device that sent the message</li>
-                <li><code>deviceName</code> - if present, the name of the device that sent the message</li>
-                <li><code>deviceType</code> - if present, the type of the device that sent the message</li>
+                <li><code>deviceId</code> - if present, the id of the remote instance that sent the message</li>
+                <li><code>deviceName</code> - if present, the name of the remote instance that sent the message</li>
+                <li><code>deviceType</code> - if present, the type of the remote instance that sent the message</li>
                 <li><code>topic</code> - the topic the message was received on</li>
                 <li><code>callStack</code> - when using the Project Call node, this contains
                     information about the call stack. This property must not be modified.</li>

--- a/nodes/project-link.html
+++ b/nodes/project-link.html
@@ -452,6 +452,11 @@
        subscribers.</p>
     <p>The node does not support MQTT wildcard characters - a fully qualified topic
        must be used.</p>
+    <h3>Limitations</h3>
+    <p>A specific source can only be another hosted instance in the same team. To
+       receive messages from remote instances, listen for broadcast messages instead.</p>
+    <p>A remote instance assigned to an application cannot be sent messages directly,
+       so it can only listen for broadcast messages.</p>
     <h3>Output</h3>
     <dl class="message-properties">
         <dt><i>msg</i> <span class="property-type">object</span></dt>
@@ -500,6 +505,9 @@
         messages from a Project Call node. If this property is not present, the
         node will be unable to respond properly.
     </p>
+    <h3>Limitations</h3>
+    <p>Sending to a specific target only works for hosted instances in the same team.
+       To reach remote instances, broadcast on a topic instead.</p>
     <h3>Input</h3>
     <dl class="message-properties">
         <dt><i>msg</i> <span class="property-type">object</span></dt>
@@ -529,6 +537,16 @@
         The node is configured with a <code>topic</code> to send on. This works
         like an MQTT topic - allowing instances to send messages targeting different
         subscribers.
+    </p>
+    <h3>Limitations</h3>
+    <p>
+        The target must be a hosted instance in the same team. A remote instance can
+        make calls, but cannot receive them.
+    </p>
+    <p>
+        The default timeout is 30 seconds. The target instance must be running and
+        have a <code>project link in</code> node listening on the same topic, so
+        logic called this way is unavailable whenever the link to the platform is down.
     </p>
     <h3>Output</h3>
     <dl class="message-properties">

--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -789,7 +789,7 @@ module.exports = function (RED) {
         } else if (node.broadcast !== true && OWNER_TYPE === 'application') {
             configOk = false
             node.status({ fill: 'red', shape: 'dot', text: 'unsupported source option' })
-            node.warn('Receiving direct messages is not supported for application assigned devices. Please update the nodes source option to use "Listen for broadcast messages".')
+            node.warn('Receiving direct messages is not supported for a remote instance assigned to an application. Please update the node source option to use "Listen for broadcast messages".')
         } else {
             mqtt.connect()
             mqtt.registerStatus(node)
@@ -839,7 +839,7 @@ module.exports = function (RED) {
                         // Check if the current project exists in the instances list
                         const projectExists = data.instances && data.instances.some(p => p.id === node.project)
                         if (!projectExists) {
-                            throw new Error(`Selected source '${node.project}' not found in FlowFuse`)
+                            throw new Error(`Selected source '${node.project}' not found in FlowFuse. Listening to a specific source only works for hosted instances in this team: to receive from remote instances, listen for broadcasts instead.`)
                         }
                     }).catch(err => {
                         mqtt.deregisterStatus(node) // prevent connections/disconnections from updating the status (this node is in error!)
@@ -904,7 +904,7 @@ module.exports = function (RED) {
                     // Check if the current project exists in the instances list
                     const projectExists = data.instances && data.instances.some(p => p.id === node.project)
                     if (!projectExists) {
-                        throw new Error(`Selected target '${node.project}' not found in FlowFuse`)
+                        throw new Error(`Selected target '${node.project}' not found in FlowFuse. Sending to a specific target only works for hosted instances in this team: to reach remote instances, broadcast on a topic instead.`)
                     }
                 }).catch(err => {
                     mqtt.deregisterStatus(node) // prevent connections/disconnections from updating the status (this node is in error!)
@@ -1024,9 +1024,11 @@ module.exports = function (RED) {
             instancesApi.getInstances()
                 .then(data => {
                     // Check if the current project exists in the instances list
-                    const projectExists = data.instances && data.instances.some(p => p.id === node.project)
+                    const target = data.instances && data.instances.find(p => p.id === node.project)
+                    node.targetName = target?.name
+                    const projectExists = !!target
                     if (!projectExists) {
-                        throw new Error(`Selected target '${node.project}' not found in FlowFuse`)
+                        throw new Error(`Selected target '${node.project}' not found in FlowFuse. A call can only target a hosted instance in this team: a remote instance can make calls, but cannot receive them.`)
                     }
                 }).catch(err => {
                     mqtt.deregisterStatus(node) // prevent connections/disconnections from updating the status (this node is in error!)
@@ -1140,7 +1142,9 @@ module.exports = function (RED) {
             const messageEvent = messageEvents[eventId]
             if (messageEvent) {
                 delete messageEvents[eventId]
-                node.error('timeout', messageEvent.msg)
+                const seconds = Math.round(timeout / 100) / 10
+                const target = node.targetName ? `'${node.targetName}'` : `instance ${node.project}`
+                node.error(`timeout after ${seconds}s waiting for a response from ${target} on topic '${node.subTopic}'. Check that the target instance is running and has a 'project link in' node listening on that topic.`, messageEvent.msg)
             }
         }
     }

--- a/test/unit/nodes/project-link_spec.js
+++ b/test/unit/nodes/project-link_spec.js
@@ -434,6 +434,37 @@ describe('project-link node', function () {
             should(pubOptions).be.an.Object()
             pubOptions.should.have.property('qos').and.equal(2)
         })
+        it('project link call should name the target and topic when a call times out', async function () {
+            const env = setup()
+            const RED = env.RED
+            const nodeEvents = {}
+            const callNode = {
+                on: (event, cb) => {
+                    nodeEvents[event] = cb
+                },
+                error: sinon.fake(),
+                type: 'project link call'
+            }
+            const getInstancesStub = sinon.stub().resolves({ count: 1, instances: [{ id: PROJECT_ID, name: 'A-PROJECT' }] })
+            InstancesApi.InstancesApi = sinon.stub().returns({
+                getInstances: getInstancesStub
+            })
+            const topic = 'cloud/project-nodes-test/call'
+            projectLinkPackage(RED)
+            const NodeConstructor = env.nodes['project link call'].NodeConstructor
+            NodeConstructor.call(callNode, { topic, project: PROJECT_ID, timeout: 0.05 })
+            await getInstancesStub
+
+            nodeEvents.input({ payload: 'test' }, sinon.fake(), sinon.fake())
+            await new Promise(resolve => setTimeout(resolve, 150))
+
+            callNode.error.called.should.be.true()
+            const message = callNode.error.args[0][0]
+            message.should.match(/timeout after 0.1s/)
+            message.should.match(/A-PROJECT/)
+            message.should.match(/cloud\/project-nodes-test\/call/)
+            message.should.match(/project link in/)
+        })
         it('project link out should publish using QoS 2', async function () {
             const env = setup()
             const RED = env.RED


### PR DESCRIPTION
Three error paths in the project link nodes gave the user nothing actionable.

- A call timeout reported only `timeout`. It now names the target instance, the topic and the limit that elapsed, and points at the missing `project link in` node.
- `Selected target/source '<id>' not found in FlowFuse` now states the rule it is enforcing: only hosted instances in the team can be addressed directly. A remote instance can make calls, but cannot receive them.
- User-facing strings in the runtime and the editor said "device". They now say remote instance. The `deviceId`, `deviceName` and `deviceType` message properties keep their names; only their descriptions changed.

The target name comes from the `getInstances()` call the node already makes at startup, so there is no extra request.

Test added for the timeout message. 47 passing, lint clean.